### PR TITLE
1: fix Jenkins CLI fails with error

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -73,4 +73,7 @@ EXPOSE 8080
 
 ENV JENKINS_TIMEZONE=UTC
 
-CMD java -jar -Dorg.apache.commons.jelly.tags.fmt.timeZone=$JENKINS_TIMEZONE /apps/jenkins/bin/jenkins.war
+CMD java -jar \
+    -Dorg.apache.commons.jelly.tags.fmt.timeZone=$JENKINS_TIMEZONE \
+    -Dhudson.diyChunking=false \
+    /apps/jenkins/bin/jenkins.war


### PR DESCRIPTION
Ticket: https://github.com/cooniur/docker-builds/issues/1

Notes:

   the upstream bug about this issue https://issues.jenkins-ci.org/browse/JENKINS-23223
   to fix add the property -Dhudson.diyChunking=false as described in
   JENKINS-23223
